### PR TITLE
Fix/list styles and focus styles

### DIFF
--- a/packages/components/src/components/bal-list/native-list.scss
+++ b/packages/components/src/components/bal-list/native-list.scss
@@ -24,6 +24,8 @@ ul.is-list li {
 }
 
 ul.is-list.has-bullet-circle li {
+  list-style: none;
+
   &::marker {
     content: none;
   }
@@ -64,6 +66,8 @@ ul.is-list.has-bullet-circle.has-bullet-purple li {
 }
 
 ul.is-list.has-bullet-check li {
+  list-style: none;
+
   &::marker {
     content: none;
   }

--- a/packages/css/scss/layout/link.sass
+++ b/packages/css/scss/layout/link.sass
@@ -10,9 +10,8 @@ a.is-link:not(.button)
     text-decoration: underline
     color: var(--bal-color-light-blue-dark)
     +fillSvg(var(--bal-color-light-blue-dark))
-  &:focus
-    &:not(:active)
-      @extend %focus-shadow
+  &:focus-visible
+    @extend %focus-shadow
   &:active,
   &:visited
     text-decoration: underline
@@ -25,10 +24,8 @@ a.is-link:not(.button)
       text-decoration: underline
       color: var(--bal-color-light-blue-2)
       +fillSvg(var(--bal-color-light-blue-2))
-    &:focus,
     &:focus-visible
-      &:not(:active)
-        @extend %focus-inverted-shadow
+      @extend %focus-inverted-shadow
     &:active,
     &:visited
       text-decoration: underline


### PR DESCRIPTION
Closes #90
Closes #93

#### Changelog

**Changed**

- removed redundant disc marker in native list "has-bullet-check" and "has-bullet-circle" (Safari)
- fixed focus behavior for native links -> focus replaced by focus-visible -> no focus on click
