### PR TITLE
fix(container-classes): padding width added to content width

### DIFF
--- a/packages/css/scss/layout/container.sass
+++ b/packages/css/scss/layout/container.sass
@@ -14,13 +14,13 @@
     padding-right: $gap
     width: 100%
   &.is-detail-page
-    max-width: 680px !important
+    max-width: 744px !important
   &.is-compact
-    max-width: 832px !important
+    max-width: 896px !important
   &.is-blog-page
-    max-width: 920px !important
+    max-width: 984px !important
   &.is-wide
-    max-width: 1400px !important
+    max-width: 1464px !important
   +tablet
     padding-left: math.div($container-offset, 2)
     padding-right: math.div($container-offset, 2)


### PR DESCRIPTION
Closes #126 

#### Changelog

**Changed**

The padding width was added to the max-width of the container to maintain the actual content width on desktop
