### PR TITLE
Feat/vertical tabs rendered next to each other

### DIFF
--- a/packages/components/src/components.d.ts
+++ b/packages/components/src/components.d.ts
@@ -1833,10 +1833,6 @@ export namespace Components {
           * If `true` the field expands over the whole width.
          */
         "inverted": boolean;
-        /**
-          * If 'true" the tab-items will be rendered next to the tabs
-         */
-        "renderItemsVertical": boolean;
         "renderLine": () => Promise<void>;
         /**
           * Go to tab with the given value
@@ -1851,6 +1847,10 @@ export namespace Components {
           * If `true` tabs are align vertically.
          */
         "vertical": Props.BalTabsVertical;
+        /**
+          * The col size of the tabs on vertical mode.
+         */
+        "verticalColSize": Props.BalTabsColSize;
     }
     interface BalTag {
         /**
@@ -4819,10 +4819,6 @@ declare namespace LocalJSX {
          */
         "onBalChange"?: (event: BalTabsCustomEvent<string>) => void;
         /**
-          * If 'true" the tab-items will be rendered next to the tabs
-         */
-        "renderItemsVertical"?: boolean;
-        /**
           * If `true` the tabs are shown as a select component on mobile
          */
         "selectOnMobile"?: boolean;
@@ -4831,6 +4827,10 @@ declare namespace LocalJSX {
           * If `true` tabs are align vertically.
          */
         "vertical"?: Props.BalTabsVertical;
+        /**
+          * The col size of the tabs on vertical mode.
+         */
+        "verticalColSize"?: Props.BalTabsColSize;
     }
     interface BalTag {
         /**

--- a/packages/components/src/components/bal-tabs/bal-tab-item/bal-tab-item.tsx
+++ b/packages/components/src/components/bal-tabs/bal-tab-item/bal-tab-item.tsx
@@ -101,12 +101,13 @@ export class TabItem {
     return (
       <Host
         class={{
-          'bal-tabs__item': this.isActive,
+          'bal-tabs-item': true,
+          'bal-tabs-item--active': this.isActive,
         }}
       >
-        <div style={{ display: this.isActive ? 'block' : 'none' }}>
-          <slot />
-        </div>
+        <slot />
+        {/* <div style={{ display: this.isActive ? 'block' : 'none' }}>
+        </div> */}
       </Host>
     )
   }

--- a/packages/components/src/components/bal-tabs/bal-tabs.sass
+++ b/packages/components/src/components/bal-tabs/bal-tabs.sass
@@ -3,6 +3,8 @@
 +block(tabs)
   display: inline-block
   position: static
+  & > .columns
+    width: 100%
   +modifiers(context-meta, context-navbar)
     +desktop
       margin-left: -1rem
@@ -10,13 +12,22 @@
     display: block
     flex: 1
     width: 100%
-  +modifier(vertical)
-    display: flex
-    flex-direction: row
-    align-items: flex-start
-    +element(tabs) 
-      +element(item)
-        width: 100%
+
+  +element(col-items)
+    padding-bottom: 0 !important
+    +modifier(vertical)
+      +tablet
+        padding-bottom: var(--bal-column-gap) !important
+  +element(col-content)
+    padding-top: 0 !important
+    padding-bottom: 0 !important
+    +modifier(vertical)
+      +tablet
+        padding-top: var(--bal-column-gap) !important
+        padding-bottom: var(--bal-column-gap) !important
+    +modifier(full)
+      padding-top: 0 !important
+      padding-bottom: 0 !important
 
   +element(tabs)
     +overflow-touch
@@ -239,321 +250,8 @@
           top: 0
           left: 0
 
-.bal-tabs__item
++block(tabs-item)
   width: 100%
-
-// bal-tabs.bal-tabs {
-//   .tabs {
-//     margin: 0 !important;
-//     position: relative;
-
-//     & > ul {
-//       margin: 0;
-//       padding: 0;
-//     }
-
-//     .selected-tab-line {
-//       height: 3px;
-//       bottom: 0;
-//       background: $blue;
-//       position: absolute;
-//       z-index: 1;
-//       border-radius: 10px;
-//     }
-
-//     .line {
-//       width: 100%;
-//       height: 2px;
-//       background: $grey-2;
-//       position: absolute;
-//       bottom: 0;
-//     }
-
-//     & > ul > li {
-//       position: relative;
-//       padding-top: 8px;
-//       padding-bottom: 8px;
-
-//       @include tablet() {
-//         &.is-right {
-//           position: absolute;
-//           right: 40px;
-//         }
-//       }
-
-//       span.bubble {
-//         background: $danger;
-//         height: 8px;
-//         width: 8px;
-//         border-radius: 50%;
-//         position: absolute;
-//         display: block;
-//         top: 12px;
-//         right: 4px;
-//       }
-
-//       & > a {
-//         min-height: 48px !important;
-//         padding: 16px;
-//         line-height: 1.2;
-//         text-decoration: none;
-
-//         color: $text-light;
-//         font-family: $title-family;
-//         font-weight: bold;
-//         font-size: 16px;
-//         line-height: 1.125;
-//         display: flex;
-//         justify-content: center;
-//         align-items: center;
-//       }
-
-//       &.is-active > a {
-//         color: $blue;
-//       }
-
-//       & > a:hover {
-//         color: $blue;
-//       }
-
-//       &.is-disabled > a,
-//       &.is-disabled > a:hover {
-//         color: $blue;
-//         cursor: default;
-//         opacity: 0.5;
-//       }
-//     }
-//   }
-//   &.is-ready {
-//     .selected-tab-line {
-//       transition: 0.4s;
-//     }
-//   }
-// }
-
-// bal-tabs.bal-tabs.is-sub-navigation {
-//   .tabs {
-//     & > ul > li {
-//       padding-top: 0;
-//       padding-bottom: 0;
-
-//       &.is-right {
-//         display: none !important;
-//       }
-
-//       span.bubble {
-//         height: 8px;
-//         width: 8px;
-//         top: 12px;
-//         right: 4px;
-//       }
-
-//       & > a {
-//         min-height: 48px;
-//         padding: 16px !important;
-//         font-size: 16px !important;
-//       }
-//     }
-
-//     .bottom-line {
-//       width: 100%;
-//       height: 3px;
-//       border-bottom: 2px solid $grey-2;
-//     }
-//   }
-// }
-
-// bal-tab-item {
-//   display: block;
-//   position: static;
-// }
-
-// @import './bal-o-steps';
-
-// bal-tabs.bal-tabs.is-vertical {
-//   .tabs {
-//     margin: 0 !important;
-//     position: relative;
-
-//     & > ul {
-//       margin: 0;
-//       padding: 0;
-
-//       align-items: center;
-//       border-bottom-color: #b3b6d4;
-//       border-bottom-style: solid;
-//       border-bottom-width: 0;
-//       display: flex;
-//       flex-grow: unset;
-//       flex-shrink: 0;
-//       justify-content: flex-start;
-//       flex-direction: column;
-
-//       li {
-//         padding-top: 0;
-//         padding-bottom: 0;
-
-//         & > a {
-//           min-height: 24px !important;
-//           height: 24px !important;
-//         }
-
-//         bal-badge {
-//           right: 4px !important;
-//           top: 4px !important;
-//         }
-//       }
-//     }
-
-//     .selected-tab-vertical-line {
-//       width: 3px;
-//       left: 0;
-//       background: $blue;
-//       position: absolute;
-//       z-index: 1;
-//       border-radius: 10px;
-//     }
-
-//     .line {
-//       width: 3px;
-//       height: 100%;
-//       background: $grey-2;
-//       position: absolute;
-//       bottom: 0;
-//     }
-//   }
-
-//   &.is-ready {
-//     .selected-tab-vertical-line {
-//       transition: 0.8s;
-//     }
-//   }
-// }
-
-// bal-tabs.bal-tabs.is-sub-navigation.is-vertical {
-//   .tabs {
-//     & > ul > li {
-//       &.is-right {
-//         display: none !important;
-//       }
-
-//       & > a {
-//         min-height: 24px !important;
-//         height: 24px !important;
-//         padding: 16px !important;
-//         font-size: 16px !important;
-//       }
-
-//       bal-badge {
-//         right: 4px !important;
-//         top: 4px !important;
-//       }
-//     }
-
-//     .bottom-line {
-//       width: 100%;
-//       height: 3px;
-//       border-bottom: 2px solid $grey-2;
-//     }
-//   }
-// }
-
-// bal-tabs.bal-tabs.is-vertical-on-mobile {
-//   @include mobile() {
-//     .tabs {
-//       margin: 0 !important;
-//       position: relative;
-
-//       .selected-tab-line {
-//         display: none !important;
-//       }
-
-//       & > ul {
-//         margin: 0;
-//         padding: 0;
-
-//         align-items: center;
-//         border-bottom-color: #b3b6d4;
-//         border-bottom-style: solid;
-//         border-bottom-width: 0;
-//         display: flex;
-//         flex-grow: unset;
-//         flex-shrink: 0;
-//         justify-content: flex-start;
-//         flex-direction: column;
-
-//         li {
-//           padding-top: 0;
-//           padding-bottom: 0;
-
-//           & > a {
-//             min-height: 24px !important;
-//             height: 24px !important;
-//           }
-
-//           bal-badge {
-//             right: 4px !important;
-//             top: 4px !important;
-//           }
-//         }
-//       }
-
-//       .selected-tab-vertical-line {
-//         width: 3px;
-//         left: 0;
-//         background: $blue;
-//         position: absolute;
-//         z-index: 1;
-//         border-radius: 10px;
-//       }
-
-//       .line {
-//         width: 3px;
-//         height: 100%;
-//         background: $grey-2;
-//         position: absolute;
-//         bottom: 0;
-//       }
-//     }
-
-//     &.is-ready {
-//       .selected-tab-vertical-line {
-//         transition: 0.8s;
-//       }
-//     }
-//   }
-// }
-
-// bal-tabs.bal-tabs.is-sub-navigation.is-vertical-on-mobile {
-//   @include mobile() {
-//     .tabs {
-//       .selected-tab-line {
-//         display: none !important;
-//       }
-
-//       & > ul > li {
-//         &.is-right {
-//           display: none !important;
-//         }
-
-//         & > a {
-//           min-height: 24px !important;
-//           height: 24px !important;
-//           padding: 16px !important;
-//           font-size: 16px !important;
-//         }
-
-//         bal-badge {
-//           right: 4px !important;
-//           top: 4px !important;
-//         }
-//       }
-
-//       .bottom-line {
-//         width: 100%;
-//         height: 3px;
-//         border-bottom: 2px solid $grey-2;
-//       }
-//     }
-//   }
-// }
+  display: none
+  +modifier(active)
+    display: block

--- a/packages/components/src/components/bal-tabs/bal-tabs.tsx
+++ b/packages/components/src/components/bal-tabs/bal-tabs.tsx
@@ -72,9 +72,9 @@ export class Tabs {
   @Prop() vertical: Props.BalTabsVertical = false
 
   /**
-   * If 'true" the tab-items will be rendered next to the tabs
+   * The col size of the tabs on vertical mode.
    */
-  @Prop() renderItemsVertical = false
+  @Prop() verticalColSize: Props.BalTabsColSize = 'one-third'
 
   /**
    * If `true` the tabs are shown as a select component on mobile
@@ -256,12 +256,20 @@ export class Tabs {
     const isSteps = this.interface === 'steps' || this.interface === 'o-steps'
     const Tabs = isSteps ? StepList : TabList
 
+    const isMobile = isPlatform('mobile')
+    const isTablet = isPlatform('tablet')
+    const isPropVertical = this.parseVertical() === true
+    const isVerticalMobile = isMobile && (this.vertical === 'mobile' || this.vertical === 'tablet')
+    const isVerticalTablet = (isMobile || isTablet) && this.vertical === 'tablet'
+
+    const isVertical = isPropVertical || isVerticalMobile || isVerticalTablet
+
     return (
       <Host
         class={{
           ...block.class(),
           ...block.modifier(`context-${this.interface}`).class(),
-          ...block.modifier('vertical').class(this.renderItemsVertical === true && this.parseVertical() === true),
+          ...block.modifier('vertical').class(this.parseVertical() === true),
           ...block.modifier('fullwidth').class(this.expanded || this.fullwidth || isSteps),
         }}
         data-value={this.tabsOptions
@@ -273,25 +281,47 @@ export class Tabs {
           .map(t => t.label)
           .join(',')}
       >
-        <Tabs
-          value={this.value}
-          context={this.interface}
-          inverted={this.inverted}
-          tabs={this.tabsOptions}
-          border={this.border}
-          expanded={this.expanded}
-          clickable={this.clickable}
-          isReady={this.isReady}
-          iconPosition={this.iconPosition}
-          onSelectTab={(e, t) => this.onSelectTab(e, t)}
-          lineWidth={this.lineWidth}
-          lineOffsetLeft={this.lineOffsetLeft}
-          lineHeight={this.lineHeight}
-          lineOffsetTop={this.lineOffsetTop}
-          vertical={this.interface === 'navbar' ? 'tablet' : this.parseVertical()}
-          selectOnMobile={this.selectOnMobile}
-        ></Tabs>
-        <slot></slot>
+        <div class="columns is-multiline">
+          <div
+            class={{
+              'column': true,
+              'is-full': !isVertical,
+              [`is-${this.verticalColSize}`]: isVertical,
+              'bal-tabs__col-items': true,
+              'bal-tabs__col-items--vertical': isVertical,
+            }}
+          >
+            <Tabs
+              value={this.value}
+              context={this.interface}
+              inverted={this.inverted}
+              tabs={this.tabsOptions}
+              border={this.border}
+              expanded={this.expanded}
+              clickable={this.clickable}
+              isReady={this.isReady}
+              iconPosition={this.iconPosition}
+              onSelectTab={(e, t) => this.onSelectTab(e, t)}
+              lineWidth={this.lineWidth}
+              lineOffsetLeft={this.lineOffsetLeft}
+              lineHeight={this.lineHeight}
+              lineOffsetTop={this.lineOffsetTop}
+              vertical={this.interface === 'navbar' ? 'tablet' : this.parseVertical()}
+              selectOnMobile={this.selectOnMobile}
+            ></Tabs>
+          </div>
+          <div
+            class={{
+              'column': true,
+              'is-full': !isVertical,
+              'bal-tabs__col-content': true,
+              'bal-tabs__col-content--vertical': isVertical,
+              'bal-tabs__col-content--full': this.verticalColSize === 'full',
+            }}
+          >
+            <slot></slot>
+          </div>
+        </div>
       </Host>
     )
   }

--- a/packages/components/src/props.d.ts
+++ b/packages/components/src/props.d.ts
@@ -93,6 +93,8 @@ export namespace Props {
   export type BalTabsInterface = 'tabs' | 'tabs-sub' | 'steps' | 'o-steps' | 'navbar' | 'meta'
   export type BalTabsIconPosition = 'horizontal' | 'vertical'
   export type BalTabsVertical = boolean | 'mobile' | 'tablet'
+  // export type BalTabsColSize = '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | '10' | '11' | '12'
+  export type BalTabsColSize = 'one-quarter' | 'one-third' | 'half' | 'two-thirds' | 'three-quarters' | 'full'
 
   export type BalTagColor =
     | 'blue'


### PR DESCRIPTION
Closes #

Makes sure the tab-items can be rendered next to the vertical tab-navigation. 

#### Changelog

**New**

- A new prop on the tabs component that will allow you to add a vertical modifier to the tabs
- Modifier styling for the tabs container
