### PR TITLE
fix: removed the width definition

### DIFF
--- a/packages/components/src/components/bal-tabs/bal-tabs.sass
+++ b/packages/components/src/components/bal-tabs/bal-tabs.sass
@@ -3,8 +3,6 @@
 +block(tabs)
   display: inline-block
   position: static
-  & > .columns
-    width: 100%
   +modifiers(context-meta, context-navbar)
     +desktop
       margin-left: -1rem


### PR DESCRIPTION
Closes #

Width definition on the columns underneath a tab component is not necessary. Removed it.

#### Changelog

**Removed**

- Removed the line that defines the 100% width.
