### PR TITLE
fix(product-slider): controls overlapping fixed

### DIFF
--- a/packages/components/src/components/bal-product-slider/bal-product-slider.sass
+++ b/packages/components/src/components/bal-product-slider/bal-product-slider.sass
@@ -3,6 +3,9 @@
   position: relative
   width: 100%
   height: 152px
+  margin-bottom: 68px
+  +tablet
+    margin-bottom: 0
 
   +element(container)
     position: absolute


### PR DESCRIPTION
##Controls overlap content below in mobile viewport

**Changed**

- added margin in VPS to prevent overlapping
