### PR TITLE
Fix/nav desktop greycard spacing

### DIFF
--- a/packages/components/src/components/bal-navigation/bal-navigation.sass
+++ b/packages/components/src/components/bal-navigation/bal-navigation.sass
@@ -173,7 +173,9 @@
           padding-bottom: 1rem
           padding-top: 1rem
         +desktop
-          margin: 0 0 .5rem
+          margin: 0 0 1rem
+          &:last-child
+            margin: 0 0 .5rem
       +modifier(context-white)
         +desktop
           > bal-card > bal-card-content


### PR DESCRIPTION
Fixes the spacings of the grey cards in desktop main navigation menu 
