### PR TITLE
fix(bal-navbar-logo): fixed custom logo overflowing header

### DIFF
--- a/packages/components/src/components/bal-navbar/bal-navbar.sass
+++ b/packages/components/src/components/bal-navbar/bal-navbar.sass
@@ -27,6 +27,7 @@
     & > a
       display: flex
       align-items: center
+      height: 100%
 
     +element(logo)
       height: calc(100% - 16px)


### PR DESCRIPTION
Closes #444 

#### Changelog

**Changed**

- had to adjust the height for the custom logo wrapped in a link to prevent the logo from overflowing

