### PR TITLE
fix: split css vars from sass base file

### DIFF
--- a/packages/components/src/styles/global.sass
+++ b/packages/components/src/styles/global.sass
@@ -1,6 +1,7 @@
 @charset "utf-8"
 
 @import 'global.utilities'
+@import 'global.variables'
 @import 'global.fonts'
 @import 'global.base'
 @import 'global.core'

--- a/packages/components/src/styles/global.variables.sass
+++ b/packages/components/src/styles/global.variables.sass
@@ -1,0 +1,1 @@
+@import '~@baloise/design-system-next-css/scss/baloise-design-system.variables'

--- a/packages/css/scss/baloise-design-system.base.sass
+++ b/packages/css/scss/baloise-design-system.base.sass
@@ -3,5 +3,4 @@
 // ----------------------------------------------
 // BASE
 // ----------------------------------------------
-@import '~@baloise/design-system-next-tokens/dist/tokens.css.sass'
 @import 'base/_all'

--- a/packages/css/scss/baloise-design-system.sass
+++ b/packages/css/scss/baloise-design-system.sass
@@ -1,6 +1,7 @@
 @charset "utf-8"
 
 @import 'baloise-design-system.utilities'
+@import 'baloise-design-system.variables'
 @import 'baloise-design-system.fonts'
 @import 'baloise-design-system.base'
 @import 'baloise-design-system.layout'

--- a/packages/css/scss/baloise-design-system.variables.sass
+++ b/packages/css/scss/baloise-design-system.variables.sass
@@ -1,3 +1,11 @@
+@charset "utf-8"
+
+// ----------------------------------------------
+// CSS Variables
+// ----------------------------------------------
+
+@import '~@baloise/design-system-next-tokens/dist/tokens.css.sass'
+
 :root
   --bal-family-primary: #{$font-family-text}
   --bal-family-secondary: #{$font-family-text}

--- a/packages/css/scss/base/_all.sass
+++ b/packages/css/scss/base/_all.sass
@@ -1,7 +1,6 @@
 @import './minireset'
 @import './normalize'
 @import './animation'
-@import './css.vars'
 
 html
   background-color: $body-background-color


### PR DESCRIPTION
## Acceptance Criteria

- [ ] Design Review by @Gagne87, @clastzoo
- [x] Technical Review by @hirsch88, @mladenplaninicic, @nobilo
- [ ] Visual test done by @hirsch88, @nobilo, @mladenplaninicic, @Gagne87, @clastzoo
- [ ] Functional test done by @hirsch88, @nobilo, @mladenplaninicic
- Browser Testing by @hirsch88, @nobilo, @mladenplaninicic, @Gagne87, @clastzoo
    - Desktop
        - [ ] Chrome
        - [ ] Edge
        - [ ] Safari
        - [ ] Firefox
    - Tablet
        - [ ] iPad (Landscape / Portrait)
    - Mobile
        - [ ] Safari iOS
        - [ ] Chrome Preview
