### PR TITLE
chore(product-slider): add line-height to the label of the slider-item

### DIFF
--- a/packages/components/src/components/bal-product-slider/bal-product-slider.sass
+++ b/packages/components/src/components/bal-product-slider/bal-product-slider.sass
@@ -127,3 +127,4 @@
       hyphens: auto
       height: 56px
       overflow: hidden
+      line-height: 1.15rem


### PR DESCRIPTION
fix the line height of the product-slider-item label when there is href prop on it

{{short description}}

## Acceptance Criteria

- [ ] Design Review by @Gagne87, @clastzoo
- [ ] Technical Review by @hirsch88, @mladenplaninicic, @nobilo
- [ ] [Style Guide](https://stenciljs.com/docs/style-guide) Review @hirsch88, @mladenplaninicic, @nobilo
- [ ] Visual test done by @hirsch88, @nobilo, @mladenplaninicic, @Gagne87, @clastzoo
- [ ] Functional test done by @hirsch88, @nobilo, @mladenplaninicic
- Browser Testing by @hirsch88, @nobilo, @mladenplaninicic, @Gagne87, @clastzoo
    - Desktop
        - [ ] Chrome
        - [ ] Edge
        - [ ] Safari
        - [ ] Firefox
    - Tablet
        - [ ] iPad (Landscape / Portrait)
    - Mobile
        - [ ] Safari iOS
        - [ ] Chrome Preview
