### PR TITLE
feat(bal-input): add Belgian specific input masks

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -110,6 +110,8 @@
     "verticaly",
     "splitted",
     "Rebranding",
-    "fakepath"
+    "fakepath",
+    "iban",
+    "enterprisenumber"
   ]
 }

--- a/packages/components/src/components.d.ts
+++ b/packages/components/src/components.d.ts
@@ -1083,7 +1083,7 @@ export namespace Components {
          */
         "inverted": boolean;
         /**
-          * Mask of the input field. It defines what the user can enter and how the format looks like. Currently, only for Switzerland formatted. Formatting for 'contract-number': '99/1.234.567-1' Formatting for 'claim-number': ('73/001217/16.9') Formatting for 'offer-number': ('98/7.654.321')
+          * Mask of the input field. It defines what the user can enter and how the format looks like. Currently, only for Switzerland formatted with addition of Belgian enterprisenumber and IBAN. Formatting for 'contract-number': '99/1.234.567-1' Formatting for 'claim-number': ('73/001217/16.9') Formatting for 'offer-number': ('98/7.654.321') Formatting for 'be-enterprise-number': ('1234.567.890') Formatting for 'be-iban': ('BE68 5390 0754 7034')
          */
         "mask"?: Props.BalInputMask;
         /**
@@ -4707,7 +4707,7 @@ declare namespace LocalJSX {
          */
         "inverted"?: boolean;
         /**
-          * Mask of the input field. It defines what the user can enter and how the format looks like. Currently, only for Switzerland formatted. Formatting for 'contract-number': '99/1.234.567-1' Formatting for 'claim-number': ('73/001217/16.9') Formatting for 'offer-number': ('98/7.654.321')
+          * Mask of the input field. It defines what the user can enter and how the format looks like. Currently, only for Switzerland formatted with addition of Belgian enterprisenumber and IBAN. Formatting for 'contract-number': '99/1.234.567-1' Formatting for 'claim-number': ('73/001217/16.9') Formatting for 'offer-number': ('98/7.654.321') Formatting for 'be-enterprise-number': ('1234.567.890') Formatting for 'be-iban': ('BE68 5390 0754 7034')
          */
         "mask"?: Props.BalInputMask;
         /**

--- a/packages/components/src/components/form/bal-input/bal-input-util.ts
+++ b/packages/components/src/components/form/bal-input/bal-input-util.ts
@@ -72,6 +72,62 @@ export function formatOffer(value: string): string {
       return `${parts[0]}/${parts[1]}.${parts[2]}.${parts[3]}`
   }
 }
+
+/**
+ *
+ * @param value: input number
+ * @output 1234.567.890
+ * @private
+ */
+export function formatBeEnterpriseNumber(value: string): string {
+  if (!value) {
+    return ''
+  }
+  const newValue = `${value}`.trim()
+  const parts = [newValue.substring(0, 4), newValue.substring(4, 7), newValue.substring(7, 10)].filter(
+    val => val.length > 0,
+  )
+  switch (parts.length) {
+    case 1:
+      return `${newValue}`
+    case 2:
+      return `${parts[0]}.${parts[1]}`
+    default:
+      return `${parts[0]}.${parts[1]}.${parts[2]}`
+  }
+}
+
+/**
+ *
+ * @param value: input number
+ * @output BE68 5390 0754 7034
+ * @private
+ */
+export function formatBeIBAN(value: string): string {
+  if (!value) {
+    return ''
+  }
+  const newValue = `${value}`.trim()
+  const parts = [
+    newValue.substring(0, 2),
+    newValue.substring(2, 6),
+    newValue.substring(6, 10),
+    newValue.substring(10, 14),
+  ].filter(val => val.length > 0)
+  switch (parts.length) {
+    case 1:
+      return `BE${newValue}`
+    case 2:
+      return `BE${parts[0]} ${parts[1]}`
+    case 3:
+      return `BE${parts[0]} ${parts[1]} ${parts[2]}`
+    default:
+      return `BE${parts[0]} ${parts[1]} ${parts[2]} ${parts[3]}`
+  }
+}
+
 export const MAX_LENGTH_CONTRACT_NUMBER = 10
 export const MAX_LENGTH_OFFER_NUMBER = 9
 export const MAX_LENGTH_CLAIM_NUMBER = 11
+export const MAX_LENGTH_BE_ENTERPRISE_NUMBER = 10
+export const MAX_LENGTH_BE_IBAN = 14

--- a/packages/components/src/components/form/bal-input/bal-input.tsx
+++ b/packages/components/src/components/form/bal-input/bal-input.tsx
@@ -220,10 +220,12 @@ export class Input implements ComponentInterface, FormInput<string | undefined>,
   @Prop({ mutable: true, reflect: true }) value?: string = undefined
 
   /**
-   * Mask of the input field. It defines what the user can enter and how the format looks like. Currently, only for Switzerland formatted.
+   * Mask of the input field. It defines what the user can enter and how the format looks like. Currently, only for Switzerland formatted with addition of Belgian enterprisenumber and IBAN.
    * Formatting for 'contract-number': '99/1.234.567-1'
    * Formatting for 'claim-number': ('73/001217/16.9')
    * Formatting for 'offer-number': ('98/7.654.321')
+   * Formatting for 'be-enterprise-number': ('1234.567.890')
+   * Formatting for 'be-iban': ('BE68 5390 0754 7034')
    */
   @Prop() mask?: Props.BalInputMask = undefined
 

--- a/packages/components/src/components/form/bal-input/bal-input.tsx
+++ b/packages/components/src/components/form/bal-input/bal-input.tsx
@@ -30,9 +30,13 @@ import {
 } from '../../../utils/form-input'
 import { Props, Events } from '../../../types'
 import {
+  formatBeEnterpriseNumber,
+  formatBeIBAN,
   formatClaim,
   formatOffer,
   formatPolicy,
+  MAX_LENGTH_BE_ENTERPRISE_NUMBER,
+  MAX_LENGTH_BE_IBAN,
   MAX_LENGTH_CLAIM_NUMBER,
   MAX_LENGTH_CONTRACT_NUMBER,
   MAX_LENGTH_OFFER_NUMBER,
@@ -382,6 +386,28 @@ export class Input implements ComponentInterface, FormInput<string | undefined>,
             }
             input.value = formatClaim(this.inputValue)
 
+            if (cursorPositionStart < this.inputValue.length) {
+              input.setSelectionRange(cursorPositionStart, cursorPositionEnd)
+            }
+            break
+          }
+          case 'be-enterprise-number': {
+            this.inputValue = input.value.replace(/\D/g, '')
+            if (this.inputValue.length > MAX_LENGTH_BE_ENTERPRISE_NUMBER) {
+              this.inputValue = this.inputValue.substring(0, MAX_LENGTH_BE_ENTERPRISE_NUMBER)
+            }
+            input.value = formatBeEnterpriseNumber(this.inputValue)
+            if (cursorPositionStart < this.inputValue.length) {
+              input.setSelectionRange(cursorPositionStart, cursorPositionEnd)
+            }
+            break
+          }
+          case 'be-iban': {
+            this.inputValue = input.value.replace(/\D/g, '')
+            if (this.inputValue.length > MAX_LENGTH_BE_IBAN) {
+              this.inputValue = this.inputValue.substring(0, MAX_LENGTH_BE_IBAN)
+            }
+            input.value = formatBeIBAN(this.inputValue)
             if (cursorPositionStart < this.inputValue.length) {
               input.setSelectionRange(cursorPositionStart, cursorPositionEnd)
             }

--- a/packages/components/src/components/form/bal-input/bal-input.tsx
+++ b/packages/components/src/components/form/bal-input/bal-input.tsx
@@ -484,6 +484,13 @@ export class Input implements ComponentInterface, FormInput<string | undefined>,
           break
         case 'offer-number':
           value = formatOffer(value)
+          break
+        case 'be-enterprise-number':
+          value = formatBeEnterpriseNumber(value)
+          break
+        case 'be-iban':
+          value = formatBeIBAN(value)
+          break
       }
     }
     const labelId = this.inputId + '-lbl'

--- a/packages/components/src/components/form/bal-input/test/bal-input-util.spec.ts
+++ b/packages/components/src/components/form/bal-input/test/bal-input-util.spec.ts
@@ -1,4 +1,4 @@
-import { formatClaim, formatOffer, formatPolicy } from '../bal-input-util'
+import { formatClaim, formatOffer, formatPolicy, formatBeEnterpriseNumber, formatBeIBAN } from '../bal-input-util'
 
 describe('bal-input-util testing:', () => {
   describe('formatClaim', () => {
@@ -81,6 +81,58 @@ describe('bal-input-util testing:', () => {
     test('11 characters', () => {
       const result = formatPolicy('90876543278')
       expect(result).toStrictEqual('90/8.765.432-7')
+    })
+  })
+  describe('formatBeEnterpriseNumber', () => {
+    test('full entry:', () => {
+      const result = formatBeEnterpriseNumber('1234567890')
+      expect(result).toStrictEqual('1234.567.890')
+    })
+    test('empty:', () => {
+      const result = formatBeEnterpriseNumber('')
+      expect(result).toStrictEqual('')
+    })
+    test('full entry:', () => {
+      const result = formatBeEnterpriseNumber('0123321123')
+      expect(result).toStrictEqual('0123.321.123')
+    })
+    test('9 characters:', () => {
+      const result = formatBeEnterpriseNumber('987654327')
+      expect(result).toStrictEqual('9876.543.27')
+    })
+    test('11 characters', () => {
+      const result = formatBeEnterpriseNumber('90876543278')
+      expect(result).toStrictEqual('9087.654.327')
+    })
+    describe('formatBeIBAN', () => {
+      test('full entry:', () => {
+        const result = formatBeIBAN('68539007547034')
+        expect(result).toStrictEqual('BE68 5390 0754 7034')
+      })
+      test('empty:', () => {
+        const result = formatBeIBAN('')
+        expect(result).toStrictEqual('')
+      })
+      test('full entry:', () => {
+        const result = formatBeIBAN('11234567890123')
+        expect(result).toStrictEqual('BE11 2345 6789 0123')
+      })
+      test('2 characters:', () => {
+        const result = formatBeIBAN('12')
+        expect(result).toStrictEqual('BE12')
+      })
+      test('4 characters', () => {
+        const result = formatBeIBAN('1234')
+        expect(result).toStrictEqual('BE12 34')
+      })
+      test('8 characters', () => {
+        const result = formatBeIBAN('12345678')
+        expect(result).toStrictEqual('BE12 3456 78')
+      })
+      test('12 characters', () => {
+        const result = formatBeIBAN('123456789012')
+        expect(result).toStrictEqual('BE12 3456 7890 12')
+      })
     })
   })
 })

--- a/packages/components/src/props.d.ts
+++ b/packages/components/src/props.d.ts
@@ -223,7 +223,7 @@ export namespace Props {
 
   export type BalInputInputMode = 'none' | 'text' | 'tel' | 'url' | 'email' | 'numeric' | 'decimal' | 'search'
 
-  export type BalInputMask = 'contract-number' | 'claim-number' | 'offer-number'
+  export type BalInputMask = 'contract-number' | 'claim-number' | 'offer-number' | 'be-enterprise-number' | 'be-iban'
 
   // From: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#input_types
   export type BalInputInputType =


### PR DESCRIPTION
Request to add 2 input masks to `bal-input`, specific to BE.

Adds `'be-enterprise-number'` and `'be-iban'` as mask options and will be formatted as such:
```
'be-enterprise-number': ('1234.567.890')
'be-iban': ('BE68 5390 0754 7034')
```